### PR TITLE
Bump @stylelint/npm-package-json-lint-config from 2.0.0 to 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "create-stylelint": "create-stylelint.mjs"
       },
       "devDependencies": {
-        "@stylelint/npm-package-json-lint-config": "^2.0.0",
+        "@stylelint/npm-package-json-lint-config": "^3.0.0",
         "@stylelint/prettier-config": "^2.0.0",
         "@stylelint/remark-preset": "^4.0.0",
         "@types/which-pm-runs": "^1.0.0",
@@ -671,17 +671,17 @@
       }
     },
     "node_modules/@stylelint/npm-package-json-lint-config": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@stylelint/npm-package-json-lint-config/-/npm-package-json-lint-config-2.0.0.tgz",
-      "integrity": "sha512-usqPs935OAkua0ws5E3lSqzRNnZefImBlbJYnRUq2mkIu8kp6rXKvHszzzquyxZgnb7e9En95ycPA754tfivEQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@stylelint/npm-package-json-lint-config/-/npm-package-json-lint-config-3.0.0.tgz",
+      "integrity": "sha512-EgGaHGMTmcUT4vxqGj3GdBBtx2GISC3ujbfFKnbQ6+J+fmkezcNVxpQvI9EdahfoTVJaRoRvW83uRhI3SavyRw==",
       "dev": true,
       "dependencies": {
-        "npm-package-json-lint": "^5.0.0",
-        "npm-package-json-lint-config-default": "^3.0.0"
+        "npm-package-json-lint": "^6.4.0",
+        "npm-package-json-lint-config-default": "^5.0.0"
       },
       "engines": {
-        "node": "^12",
-        "npm": "^6"
+        "node": ">=14",
+        "npm": ">=8"
       },
       "funding": {
         "type": "opencollective",
@@ -828,12 +828,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
-      "dev": true
-    },
-    "node_modules/@types/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
     "node_modules/@types/semver": {
@@ -1310,6 +1304,15 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "node_modules/builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.0.0"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1564,19 +1567,18 @@
       }
     },
     "node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.0.0.tgz",
+      "integrity": "sha512-da1EafcpH6b/TD8vDRaWV7xFINlHlF6zKsGwS1TsuVJTZRkquaS5HTMq7uq6h31619QjbsYl21gVDOm32KM1vQ==",
       "dev": true,
       "dependencies": {
-        "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
         "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
+        "path-type": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/cosmiconfig/node_modules/json-parse-even-better-errors": {
@@ -1607,15 +1609,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cosmiconfig/node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/cross-spawn": {
@@ -3643,44 +3636,24 @@
       }
     },
     "node_modules/meow": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-6.1.1.tgz",
-      "integrity": "sha512-3YffViIt2QWgTy6Pale5QpopX/IvU3LPL03jOTqp6pGj3VjesdO/U8CuHMKpnQr4shCNCM5fd5XFFvIIl6JBHg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
+      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
       "dev": true,
       "dependencies": {
         "@types/minimist": "^1.2.0",
         "camelcase-keys": "^6.2.2",
+        "decamelize": "^1.2.0",
         "decamelize-keys": "^1.1.0",
         "hard-rejection": "^2.1.0",
-        "minimist-options": "^4.0.2",
-        "normalize-package-data": "^2.5.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^3.0.0",
         "read-pkg-up": "^7.0.1",
         "redent": "^3.0.0",
         "trim-newlines": "^3.0.0",
-        "type-fest": "^0.13.1",
-        "yargs-parser": "^18.1.3"
+        "type-fest": "^0.18.0",
+        "yargs-parser": "^20.2.3"
       },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/meow/node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/meow/node_modules/type-fest": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -3688,17 +3661,43 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/meow/node_modules/yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+    "node_modules/meow/node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
       "dev": true,
       "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
+        "lru-cache": "^6.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
+      }
+    },
+    "node_modules/meow/node_modules/normalize-package-data": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/meow/node_modules/type-fest": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+      "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge-stream": {
@@ -4355,46 +4354,48 @@
       }
     },
     "node_modules/npm-package-json-lint": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-5.4.2.tgz",
-      "integrity": "sha512-DH1MSvYvm+cuQFXcPehIIu/WiYzMYs7BOxlhOOFHaH2SNrA+P2uDtTEe5LOG90Ci7PTwgF/dCmSKM2HWTgWXNA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-6.4.0.tgz",
+      "integrity": "sha512-cuXAJJB1Rdqz0UO6w524matlBqDBjcNt7Ru+RDIu4y6RI1gVqiWBnylrK8sPRk81gGBA0X8hJbDXolVOoTc+sA==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.6",
         "ajv-errors": "^1.0.1",
         "chalk": "^4.1.2",
-        "cosmiconfig": "^7.0.1",
-        "debug": "^4.3.2",
-        "globby": "^11.0.4",
-        "ignore": "^5.1.9",
+        "cosmiconfig": "^8.0.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "ignore": "^5.2.0",
         "is-plain-obj": "^3.0.0",
-        "jsonc-parser": "^3.0.0",
+        "jsonc-parser": "^3.2.0",
         "log-symbols": "^4.1.0",
-        "meow": "^6.1.1",
+        "meow": "^9.0.0",
         "plur": "^4.0.0",
-        "semver": "^7.3.5",
+        "semver": "^7.3.8",
         "slash": "^3.0.0",
-        "strip-json-comments": "^3.1.1"
+        "strip-json-comments": "^3.1.1",
+        "type-fest": "^3.2.0",
+        "validate-npm-package-name": "^5.0.0"
       },
       "bin": {
-        "npmPkgJsonLint": "src/cli.js"
+        "npmPkgJsonLint": "dist/cli.js"
       },
       "engines": {
-        "node": ">=10.0.0",
+        "node": ">=14.0.0",
         "npm": ">=6.0.0"
       }
     },
     "node_modules/npm-package-json-lint-config-default": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/npm-package-json-lint-config-default/-/npm-package-json-lint-config-default-3.0.0.tgz",
-      "integrity": "sha512-1eOHUSg4Pg1lDp75NJ/pTnYU3/vn7WIL+3MG5KWtrUEFtIuBX/yLGABTFZ4+sP73bQYu/Nla07icJjezQP6SnA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/npm-package-json-lint-config-default/-/npm-package-json-lint-config-default-5.0.0.tgz",
+      "integrity": "sha512-guf+bECFtVz6sekPBmkf/m/k8gbX16F5S9wZI6cvhrkSEl+AhM2GoCU6alOhbaGbkn0PgbNRcRrsuu4jWEZFHQ==",
       "dev": true,
       "engines": {
-        "node": ">=10.0.0",
+        "node": ">=14.0.0",
         "npm": ">=6.0.0"
       },
       "peerDependencies": {
-        "npm-package-json-lint": "^5.0.0"
+        "npm-package-json-lint": "^6.0.0"
       }
     },
     "node_modules/npm-package-json-lint/node_modules/chalk": {
@@ -4448,6 +4449,18 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-package-json-lint/node_modules/type-fest": {
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.5.6.tgz",
+      "integrity": "sha512-6bd2bflx8ed7c99tc6zSTIzHr1/QG29bQoK4Qh8MYGnlPbODUzGxklLShjwc/xWQQFHgIci+y5Arv7Rbb0LjXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6969,6 +6982,18 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/validate-npm-package-name": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
+      "integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
+      "dev": true,
+      "dependencies": {
+        "builtins": "^5.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/vfile": {
       "version": "5.3.6",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.6.tgz",
@@ -7323,6 +7348,15 @@
       "dev": true,
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/yocto-queue": {
@@ -7720,13 +7754,13 @@
       "dev": true
     },
     "@stylelint/npm-package-json-lint-config": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@stylelint/npm-package-json-lint-config/-/npm-package-json-lint-config-2.0.0.tgz",
-      "integrity": "sha512-usqPs935OAkua0ws5E3lSqzRNnZefImBlbJYnRUq2mkIu8kp6rXKvHszzzquyxZgnb7e9En95ycPA754tfivEQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@stylelint/npm-package-json-lint-config/-/npm-package-json-lint-config-3.0.0.tgz",
+      "integrity": "sha512-EgGaHGMTmcUT4vxqGj3GdBBtx2GISC3ujbfFKnbQ6+J+fmkezcNVxpQvI9EdahfoTVJaRoRvW83uRhI3SavyRw==",
       "dev": true,
       "requires": {
-        "npm-package-json-lint": "^5.0.0",
-        "npm-package-json-lint-config-default": "^3.0.0"
+        "npm-package-json-lint": "^6.4.0",
+        "npm-package-json-lint-config-default": "^5.0.0"
       }
     },
     "@stylelint/prettier-config": {
@@ -7866,12 +7900,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
-      "dev": true
-    },
-    "@types/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
     "@types/semver": {
@@ -8206,6 +8234,15 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+      "dev": true,
+      "requires": {
+        "semver": "^7.0.0"
+      }
+    },
     "cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -8380,16 +8417,15 @@
       }
     },
     "cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.0.0.tgz",
+      "integrity": "sha512-da1EafcpH6b/TD8vDRaWV7xFINlHlF6zKsGwS1TsuVJTZRkquaS5HTMq7uq6h31619QjbsYl21gVDOm32KM1vQ==",
       "dev": true,
       "requires": {
-        "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
         "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
+        "path-type": "^4.0.0"
       },
       "dependencies": {
         "json-parse-even-better-errors": {
@@ -8415,12 +8451,6 @@
             "json-parse-even-better-errors": "^2.3.0",
             "lines-and-columns": "^1.1.6"
           }
-        },
-        "yaml": {
-          "version": "1.10.2",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-          "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-          "dev": true
         }
       }
     },
@@ -9846,45 +9876,51 @@
       "dev": true
     },
     "meow": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-6.1.1.tgz",
-      "integrity": "sha512-3YffViIt2QWgTy6Pale5QpopX/IvU3LPL03jOTqp6pGj3VjesdO/U8CuHMKpnQr4shCNCM5fd5XFFvIIl6JBHg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
+      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
       "dev": true,
       "requires": {
         "@types/minimist": "^1.2.0",
         "camelcase-keys": "^6.2.2",
+        "decamelize": "^1.2.0",
         "decamelize-keys": "^1.1.0",
         "hard-rejection": "^2.1.0",
-        "minimist-options": "^4.0.2",
-        "normalize-package-data": "^2.5.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^3.0.0",
         "read-pkg-up": "^7.0.1",
         "redent": "^3.0.0",
         "trim-newlines": "^3.0.0",
-        "type-fest": "^0.13.1",
-        "yargs-parser": "^18.1.3"
+        "type-fest": "^0.18.0",
+        "yargs-parser": "^20.2.3"
       },
       "dependencies": {
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
-        },
-        "type-fest": {
-          "version": "0.13.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-          "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-          "dev": true
-        },
-        "yargs-parser": {
-          "version": "18.1.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+        "hosted-git-info": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+          "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
           "dev": true,
           "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
+            "lru-cache": "^6.0.0"
           }
+        },
+        "normalize-package-data": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+          "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^4.0.1",
+            "is-core-module": "^2.5.0",
+            "semver": "^7.3.4",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "type-fest": {
+          "version": "0.18.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+          "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+          "dev": true
         }
       }
     },
@@ -10281,26 +10317,28 @@
       "dev": true
     },
     "npm-package-json-lint": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-5.4.2.tgz",
-      "integrity": "sha512-DH1MSvYvm+cuQFXcPehIIu/WiYzMYs7BOxlhOOFHaH2SNrA+P2uDtTEe5LOG90Ci7PTwgF/dCmSKM2HWTgWXNA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-6.4.0.tgz",
+      "integrity": "sha512-cuXAJJB1Rdqz0UO6w524matlBqDBjcNt7Ru+RDIu4y6RI1gVqiWBnylrK8sPRk81gGBA0X8hJbDXolVOoTc+sA==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.6",
         "ajv-errors": "^1.0.1",
         "chalk": "^4.1.2",
-        "cosmiconfig": "^7.0.1",
-        "debug": "^4.3.2",
-        "globby": "^11.0.4",
-        "ignore": "^5.1.9",
+        "cosmiconfig": "^8.0.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "ignore": "^5.2.0",
         "is-plain-obj": "^3.0.0",
-        "jsonc-parser": "^3.0.0",
+        "jsonc-parser": "^3.2.0",
         "log-symbols": "^4.1.0",
-        "meow": "^6.1.1",
+        "meow": "^9.0.0",
         "plur": "^4.0.0",
-        "semver": "^7.3.5",
+        "semver": "^7.3.8",
         "slash": "^3.0.0",
-        "strip-json-comments": "^3.1.1"
+        "strip-json-comments": "^3.1.1",
+        "type-fest": "^3.2.0",
+        "validate-npm-package-name": "^5.0.0"
       },
       "dependencies": {
         "chalk": {
@@ -10334,13 +10372,19 @@
             "chalk": "^4.1.0",
             "is-unicode-supported": "^0.1.0"
           }
+        },
+        "type-fest": {
+          "version": "3.5.6",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.5.6.tgz",
+          "integrity": "sha512-6bd2bflx8ed7c99tc6zSTIzHr1/QG29bQoK4Qh8MYGnlPbODUzGxklLShjwc/xWQQFHgIci+y5Arv7Rbb0LjXw==",
+          "dev": true
         }
       }
     },
     "npm-package-json-lint-config-default": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/npm-package-json-lint-config-default/-/npm-package-json-lint-config-default-3.0.0.tgz",
-      "integrity": "sha512-1eOHUSg4Pg1lDp75NJ/pTnYU3/vn7WIL+3MG5KWtrUEFtIuBX/yLGABTFZ4+sP73bQYu/Nla07icJjezQP6SnA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/npm-package-json-lint-config-default/-/npm-package-json-lint-config-default-5.0.0.tgz",
+      "integrity": "sha512-guf+bECFtVz6sekPBmkf/m/k8gbX16F5S9wZI6cvhrkSEl+AhM2GoCU6alOhbaGbkn0PgbNRcRrsuu4jWEZFHQ==",
       "dev": true,
       "requires": {}
     },
@@ -12176,6 +12220,15 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "validate-npm-package-name": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
+      "integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
+      "dev": true,
+      "requires": {
+        "builtins": "^5.0.0"
+      }
+    },
     "vfile": {
       "version": "5.3.6",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.6.tgz",
@@ -12394,6 +12447,12 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
       "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
+      "dev": true
+    },
+    "yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true
     },
     "yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "which-pm-runs": "^1.1.0"
   },
   "devDependencies": {
-    "@stylelint/npm-package-json-lint-config": "^2.0.0",
+    "@stylelint/npm-package-json-lint-config": "^3.0.0",
     "@stylelint/prettier-config": "^2.0.0",
     "@stylelint/remark-preset": "^4.0.0",
     "@types/which-pm-runs": "^1.0.0",


### PR DESCRIPTION
> Which issue, if any, is this issue related to?

None, it's a dependency bump.

> Is there anything in the PR that needs further explanation?

In particular, noticed that this resolves an error when running `npm install` about incompatible engine versions.

```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@stylelint/npm-package-json-lint-config@2.0.0',
npm WARN EBADENGINE   required: { node: '^12', npm: '^6' },
npm WARN EBADENGINE   current: { node: 'v18.10.0', npm: '8.19.2' }
npm WARN EBADENGINE }
```

Upgrading fixes this!